### PR TITLE
Added lines for the bResetTrigger

### DIFF
--- a/Puzzle1/Source/Puzzle1/Prop/PressurePlateTrigger.cpp
+++ b/Puzzle1/Source/Puzzle1/Prop/PressurePlateTrigger.cpp
@@ -62,7 +62,8 @@ void APressurePlateTrigger::OnBeginOverlap(UPrimitiveComponent* OverlappedCompon
 	{
 		MoveableMesh->Move(true);
 		Interact(true);
-
+		
+		bResetTrigger = true;
 		bIsTriggered = true;
 	}
 }
@@ -74,6 +75,7 @@ void APressurePlateTrigger::OnEndOverlap(UPrimitiveComponent* OverlappedComponen
 		MoveableMesh->Move(false);
 		Interact(false);
 
+		bResetTrigger = false;
 		bIsTriggered = false;
 	}
 }


### PR DESCRIPTION
For my code at least, if the value of `bResetTrigger` were not altered, the pressure plate would never go back down once an actor stepped away. Maybe there was something I was missing here, but in the video tutorial you never did anything with these values, yet it still somehow worked...